### PR TITLE
add file-level brief and details at the top of the output

### DIFF
--- a/doxybook/templates/c/file.jinja
+++ b/doxybook/templates/c/file.jinja
@@ -1,5 +1,9 @@
 ## File {{ file.location }}
 
+{{ file.brief }}
+
+{{ file.details }}
+
 {% set macros = file.query(kinds=['define']) -%}
 {%- set structures_types = file.query(kinds=['struct', 'typedef', 'enum', 'union']) -%}
 {%- set functions = file.query(kinds=['function']) -%}

--- a/doxybook/templates/cpp/file.jinja
+++ b/doxybook/templates/cpp/file.jinja
@@ -1,5 +1,9 @@
 ## File {{ file.location }}
 
+{{ file.brief }}
+
+{{ file.details }}
+
 {% set namespaces = file.query(kinds=['namespace']) -%}
 {%- set classes = file.query(kinds=['struct', 'class', 'interface']) -%}
 {%- set macros = file.query(kinds=['define']) -%}


### PR DESCRIPTION
With the following file-level comment:
```c++
/**
 * @file
 * @brief Arduino Nano ESP32 Board Support Package
 *
 * This file provides definitions and functions for the Arduino Nano ESP32 board.
 * Pin definitions are provided using @ref PIN_A0, @ref PIN_A1, etc. macros.
 * The @ref bsp_led_t enum defines the LEDs on the board.
 * The @ref bsp_led_set() function can be used to turn LEDs on and off.
 * Before using the LEDs, they must be initialized using @ref bsp_leds_init().
 */

```

We get the following output:

---

## File bsp/arduino-nano-esp32.h

_Arduino Nano ESP32 Board Support Package._

This file provides definitions and functions for the Arduino Nano ESP32 board. Pin definitions are provided using [**PIN\_A0**](#define-pin_a0),[**PIN\_A1**](#define-pin_a1), etc. macros. The[**bsp\_led\_t**](#enum-bsp_led_t)enum defines the LEDs on the board. The[**bsp\_led\_set()**](#function-bsp_led_set)function can be used to turn LEDs on and off. Before using the LEDs, they must be initialized using[**bsp\_leds\_init()**](#function-bsp_leds_init).

---

Note, there are spaces missing around the references. Haven't found the bug yet.