### PR TITLE
fix: excape pipe symbol in the markdown table

### DIFF
--- a/doxybook/templates/table.jinja
+++ b/doxybook/templates/table.jinja
@@ -9,7 +9,7 @@
 {% elif node.is_enum or node.is_function or node.is_variable or node.is_union or node.is_typedef -%}
 | {{node.prefix}} {{node.type}} | [**{{node.name_long if node.is_group else node.name_short}}**]({{node.relative_link}}) {{node.params}} {{node.suffix}}<br>{{node.brief}} |
 {% else -%}
-| {{node.prefix}} {{node.type}} | [**{{node.name_long if node.is_group else node.name_short}}**]({{node.relative_link}}) {{node.params}} {{node.suffix}}<br>{{node.brief}} |
+| {{node.prefix}} {{node.type}} | [**{{node.name_long if node.is_group else node.name_short}}**]({{node.relative_link}}) {{node.params}} {{node.suffix | replace('|', '\|')}}<br>{{node.brief}} |
 {% endif -%}
 {%- endfor -%}
 {%- endif -%}


### PR DESCRIPTION
let's say, my C program has `#define LED_STRIP_SET_RGB_ORDER(R, G, B) (R << 0 | G << 2 | B << 4)` It's rendered in the markdown file as a table. 

As you see, in the define, there's a pipe (`|`) symbol which is valid in C language. If we convert it into Markdown, we should add an escape. Because `|` has a special meaning in the Markdown table. 