### PR TITLE
fix: handle fully anonymous union/struct members without name

### DIFF
--- a/doxybook/node.py
+++ b/doxybook/node.py
@@ -105,7 +105,8 @@ class Node:
         self._children.append(child)
 
     def sort_children(self):
-        self._children.sort(key=lambda x: x._name, reverse=False)
+        # `_name` should always be a string
+        self._children.sort(key=lambda x: x._name or '', reverse=False)
 
     def _check_for_children(self):
         for innergroup in self._xml.findall('innergroup'):
@@ -265,7 +266,7 @@ class Node:
 
         name = self._xml.find('name')
         if name is not None:
-            self._name = name.text
+            self._name = name.text or ''
         else:
             self._name = ''
 
@@ -285,6 +286,9 @@ class Node:
     ) -> ['Node']:
         ret = []
         for child in self._children:
+            if child.is_anonymous_wrapper_member:
+                continue
+
             bool_stmts = []
             if visibility is not None:
                 visibility = Visibility(visibility)
@@ -301,6 +305,13 @@ class Node:
                 ret.append(child)
 
         return ret
+
+    @property
+    def is_anonymous_wrapper_member(self) -> bool:
+        """Whether this node is Doxygen's synthetic memberdef for a fully
+        anonymous union/struct field (no instance name), whose real members
+        are flattened directly into the parent compound."""
+        return self.is_variable and self._name == ''
 
     @property
     def is_static(self) -> bool:

--- a/example/c/test_comp/include/comp1.h
+++ b/example/c/test_comp/include/comp1.h
@@ -75,3 +75,16 @@ union union_comp1
     comp1 a;
     comp1 b;
 };
+
+
+/**
+ * @brief Struct with a fully anonymous union member (no instance name).
+ *
+ */
+typedef struct {
+    int kind;             /*!< discriminator for the union below */
+    union {
+        int int_value;    /*!< value when kind is an integer */
+        float float_value; /*!< value when kind is a float */
+    };
+} anonymous_union_comp1_t;


### PR DESCRIPTION
## Description

Fixes a `TypeError` crash in `esp-doxybook`/`doxybook` when a struct contains a fully anonymous union/struct member with no instance name (e.g. `union { int a; float b; };`), as opposed to a named anonymous field (`struct { ... } flags;`) which already worked. The root cause is in `Node._check_attrs`: Doxygen emits an empty `<name/>` for this wrapper `memberdef`, and `ElementTree`'s `.text` on an empty element is `None` rather than `''`, so `Node._name` ended up `None` and crashed `sort_children()` when sorting siblings alongside real `str` names. The fix falls back to `''` at the source and also hardens the sort key defensively; a new `Node.is_anonymous_wrapper_member` check filters this synthetic wrapper out of `query()` so it no longer renders as a phantom, nameless entry in the parent's Variables list. A regression-test struct (`anonymous_union_comp1_t`) was added to `example/c/test_comp/include/comp1.h`

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

Verified locally on `anonymous_union_comp1_t`.

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

